### PR TITLE
Update one piece of translations in the "使用母语写注释" part.

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,7 +90,7 @@ toggleModal(false);
 _Bad 👎🏻_
 
 ```javascript
-// 隐藏错误弹窗
+// Hide modal window on error.
 toggleModal(false);
 ```
 


### PR DESCRIPTION
The author aims to write comments in your mother language is a shit code style. No need to translation here. Because any Chinese character would be a part of Chinese users' mother language, but for other languages user, it might confuse them. Keep using English here to maintain consistency.