### PR TITLE
fix zh-CN translations

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -83,14 +83,14 @@ const callbackDebounceRate = 700;
 _Good 👍🏻_
 
 ```javascript
-// Закриваємо модальне віконечко при виникненні помилки.
+// 隐藏错误弹窗
 toggleModal(false);
 ```
 
 _Bad 👎🏻_
 
 ```javascript
-// 隐藏错误弹窗
+// Hide modal window on error.
 toggleModal(false);
 ```
 


### PR DESCRIPTION
`write comments in a language that is different from the language you use to write the code` but the bad example is written in Chinese

There is not code based Chinese(in the example), so why writing comments with Chinese is wrong?